### PR TITLE
Add AJAX pagination for front page feed

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -50,14 +50,88 @@ function obdc_simplex_news_get_post_views( $post_id = null ) {
  * @return string The category name or empty string.
  */
 function obdc_simplex_news_get_first_category_name( $post_id = null ) {
-	if ( ! $post_id ) {
-		$post_id = get_the_ID();
-	}
+        if ( ! $post_id ) {
+                $post_id = get_the_ID();
+        }
 
-	$categories = get_the_category( $post_id );
-	if ( ! empty( $categories ) ) {
-		return esc_html( $categories[0]->name );
-	}
+        $categories = get_the_category( $post_id );
+        if ( ! empty( $categories ) ) {
+                return esc_html( $categories[0]->name );
+        }
 
-	return '';
+        return '';
+}
+
+
+/**
+ * Get the IDs of posts displayed in the hero and highlight areas on the front page.
+ *
+ * @return array List of post IDs to exclude from the feed loop.
+ */
+function obdc_simplex_news_get_front_page_excluded_post_ids() {
+        $excluded_post_ids = array();
+        $hero_post_id      = null;
+
+        // Attempt to fetch a featured hero post first.
+        $featured_hero_query = new WP_Query(
+                array(
+                        'posts_per_page' => 1,
+                        'meta_key'       => '_featured_on_home',
+                        'meta_value'     => '1',
+                        'orderby'        => 'date',
+                        'order'          => 'DESC',
+                        'fields'         => 'ids',
+                )
+        );
+
+        if ( ! empty( $featured_hero_query->posts ) ) {
+                $hero_post_id = (int) $featured_hero_query->posts[0];
+        }
+
+        wp_reset_postdata();
+
+        // Fallback to the latest post if no featured hero exists.
+        if ( ! $hero_post_id ) {
+                $latest_hero_query = new WP_Query(
+                        array(
+                                'posts_per_page' => 1,
+                                'orderby'        => 'date',
+                                'order'          => 'DESC',
+                                'fields'         => 'ids',
+                        )
+                );
+
+                if ( ! empty( $latest_hero_query->posts ) ) {
+                        $hero_post_id = (int) $latest_hero_query->posts[0];
+                }
+
+                wp_reset_postdata();
+        }
+
+        if ( $hero_post_id ) {
+                $excluded_post_ids[] = $hero_post_id;
+        }
+
+        // Fetch highlight posts, excluding the hero when available.
+        $highlights_args = array(
+                'posts_per_page' => 2,
+                'orderby'        => 'date',
+                'order'          => 'DESC',
+                'fields'         => 'ids',
+                'post_status'    => 'publish',
+        );
+
+        if ( $hero_post_id ) {
+                $highlights_args['post__not_in'] = array( $hero_post_id );
+        }
+
+        $highlights_query = new WP_Query( $highlights_args );
+
+        if ( ! empty( $highlights_query->posts ) ) {
+                $excluded_post_ids = array_merge( $excluded_post_ids, array_map( 'intval', $highlights_query->posts ) );
+        }
+
+        wp_reset_postdata();
+
+        return array_values( array_unique( $excluded_post_ids ) );
 }

--- a/js/front-page.js
+++ b/js/front-page.js
@@ -1,0 +1,150 @@
+(function () {
+        const onReady = (callback) => {
+                if ( document.readyState !== 'loading' ) {
+                        callback();
+                        return;
+                }
+
+                document.addEventListener('DOMContentLoaded', callback);
+        };
+
+        onReady(() => {
+                const loadMoreButton = document.querySelector('.loadmore');
+
+                if ( ! loadMoreButton ) {
+                        return;
+                }
+
+                const feedContainer = loadMoreButton.closest('.feed');
+
+                if ( ! feedContainer ) {
+                        return;
+                }
+
+                const postsContainer = feedContainer.querySelector('[data-feed-items]');
+                const endpoint = loadMoreButton.dataset.endpoint;
+                const defaultText = loadMoreButton.dataset.buttonText || loadMoreButton.textContent;
+                const loadingText = loadMoreButton.dataset.loadingText || defaultText;
+                let isLoading = false;
+
+                const disableButton = () => {
+                        loadMoreButton.disabled = true;
+                        loadMoreButton.setAttribute('aria-disabled', 'true');
+                        loadMoreButton.classList.add('is-disabled');
+                        loadMoreButton.classList.remove('is-loading');
+                        loadMoreButton.textContent = defaultText;
+                };
+
+                const enableButton = () => {
+                        loadMoreButton.disabled = false;
+                        loadMoreButton.removeAttribute('disabled');
+                        loadMoreButton.setAttribute('aria-disabled', 'false');
+                        loadMoreButton.classList.remove('is-disabled');
+                        loadMoreButton.textContent = defaultText;
+                };
+
+                const hasMorePages = () => {
+                        const currentPage = parseInt(loadMoreButton.dataset.currentPage || '1', 10);
+                        const maxPages = parseInt(loadMoreButton.dataset.maxPages || '1', 10);
+
+                        return currentPage < maxPages;
+                };
+
+                const initialiseState = () => {
+                        if ( ! endpoint || ! hasMorePages() ) {
+                                disableButton();
+                                return false;
+                        }
+
+                        enableButton();
+                        return true;
+                };
+
+                if ( ! initialiseState() ) {
+                        return;
+                }
+
+                loadMoreButton.addEventListener('click', () => {
+                        if ( isLoading || loadMoreButton.disabled ) {
+                                return;
+                        }
+
+                        const currentPage = parseInt(loadMoreButton.dataset.currentPage || '1', 10);
+                        const maxPages = parseInt(loadMoreButton.dataset.maxPages || '1', 10);
+                        const nextPage = currentPage + 1;
+
+                        if ( nextPage > maxPages ) {
+                                disableButton();
+                                return;
+                        }
+
+                        isLoading = true;
+                        loadMoreButton.disabled = true;
+                        loadMoreButton.setAttribute('aria-disabled', 'true');
+                        loadMoreButton.classList.add('is-loading');
+                        loadMoreButton.textContent = loadingText;
+
+                        let requestUrl;
+
+                        try {
+                                const url = new window.URL(endpoint);
+                                url.searchParams.set('page', String(nextPage));
+                                requestUrl = url.toString();
+                        } catch ( error ) {
+                                const separator = endpoint.indexOf('?') === -1 ? '?' : '&';
+                                requestUrl = endpoint + separator + 'page=' + nextPage;
+                        }
+
+                        const headers = { Accept: 'application/json' };
+
+                        if ( loadMoreButton.dataset.nonce ) {
+                                headers['X-WP-Nonce'] = loadMoreButton.dataset.nonce;
+                        }
+
+                        window
+                                .fetch(requestUrl, {
+                                        method: 'GET',
+                                        headers,
+                                        credentials: 'same-origin',
+                                })
+                                .then((response) => {
+                                        if ( ! response.ok ) {
+                                                throw new Error('Request failed with status ' + response.status);
+                                        }
+
+                                        return response.json();
+                                })
+                                .then((data) => {
+                                        if ( data && typeof data.maxPages !== 'undefined' ) {
+                                                loadMoreButton.dataset.maxPages = data.maxPages;
+                                        }
+
+                                        if ( data && data.html ) {
+                                                if ( postsContainer ) {
+                                                        postsContainer.insertAdjacentHTML('beforeend', data.html);
+                                                } else {
+                                                        loadMoreButton.insertAdjacentHTML('beforebegin', data.html);
+                                                }
+                                        }
+
+                                        loadMoreButton.dataset.currentPage = String(nextPage);
+
+                                        if ( ! hasMorePages() || ! data || ! data.html ) {
+                                                disableButton();
+                                        } else {
+                                                enableButton();
+                                        }
+                                })
+                                .catch((error) => {
+                                        // eslint-disable-next-line no-console
+                                        console.error('Load more request failed:', error);
+                                        enableButton();
+                                })
+                                .finally(() => {
+                                        loadMoreButton.classList.remove('is-loading');
+                                        loadMoreButton.textContent = defaultText;
+                                        isLoading = false;
+                                });
+                });
+        });
+})();


### PR DESCRIPTION
## Summary
- add a reusable helper and REST endpoint so the front page feed can fetch additional pages without duplicating hero/highlight posts
- refresh the front-page markup to include data attributes and load-more state for the AJAX workflow
- enqueue a front-page script that requests the next page, appends new cards, and disables the button at the pagination limit

## Testing
- php -l front-page.php
- php -l functions.php
- php -l inc/helpers.php

------
https://chatgpt.com/codex/tasks/task_e_68cd5db4491483319e7d2f5183a281e2