### PR TITLE
Refactor home highlights to use sticky posts

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -14,9 +14,18 @@
 
 get_header();
 
+$featured_data     = array();
 $excluded_post_ids = array();
 
-if ( function_exists( 'obdc_simplex_news_get_front_page_excluded_post_ids' ) ) {
+if ( function_exists( 'obdc_simplex_news_get_front_page_featured_data' ) ) {
+        $featured_data = obdc_simplex_news_get_front_page_featured_data();
+}
+
+set_query_var( 'obdc_featured_data', $featured_data );
+
+if ( ! empty( $featured_data['excluded_ids'] ) ) {
+        $excluded_post_ids = $featured_data['excluded_ids'];
+} elseif ( function_exists( 'obdc_simplex_news_get_front_page_excluded_post_ids' ) ) {
         $excluded_post_ids = obdc_simplex_news_get_front_page_excluded_post_ids();
 }
 

--- a/template-parts/sidebar/most-read.php
+++ b/template-parts/sidebar/most-read.php
@@ -5,15 +5,36 @@
  * @package ObDC-simplex-news
  */
 
+// Prevent overlap with hero/highlight posts when rendered on the front page.
+$excluded_featured_ids = array();
+
+if ( is_front_page() ) {
+        $featured_data = get_query_var( 'obdc_featured_data' );
+
+        if ( empty( $featured_data ) && function_exists( 'obdc_simplex_news_get_front_page_featured_data' ) ) {
+                $featured_data = obdc_simplex_news_get_front_page_featured_data();
+        }
+
+        if ( ! empty( $featured_data['excluded_ids'] ) ) {
+                $excluded_featured_ids = array_map( 'intval', (array) $featured_data['excluded_ids'] );
+        }
+}
+
 // Get most viewed posts (requires plugin like 'Post Views Counter' or custom table)
 // Using meta_key 'post_views' as specified in ObDC documentation
-$most = new WP_Query( array(
-	'posts_per_page' => 6,
-	'meta_key'       => 'post_views',
-	'orderby'        => 'meta_value_num',
-	'order'          => 'DESC',
-	'post_status'    => 'publish',
-) );
+$most_query_args = array(
+        'posts_per_page' => 6,
+        'meta_key'       => 'post_views',
+        'orderby'        => 'meta_value_num',
+        'order'          => 'DESC',
+        'post_status'    => 'publish',
+);
+
+if ( ! empty( $excluded_featured_ids ) ) {
+        $most_query_args['post__not_in'] = $excluded_featured_ids;
+}
+
+$most = new WP_Query( $most_query_args );
 
 if ( $most->have_posts() ) : ?>
 	<div class="box">


### PR DESCRIPTION
## Summary
- replace the featured meta queries with sticky post aware helpers for the hero and highlight slots
- share the calculated featured IDs with the front page feed and templates to avoid duplicates and fall back to recent posts when needed
- stop the “Mais lidas” widget from repeating the hero or highlight entries on the front page

## Testing
- php -l inc/helpers.php
- php -l front-page.php
- php -l template-parts/home/hero.php
- php -l template-parts/home/highlights.php
- php -l template-parts/sidebar/most-read.php

------
https://chatgpt.com/codex/tasks/task_e_68cd697b11948331bf94f77a3d343b02