### PR TITLE
Add infinite scroll with load more fallback

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -87,7 +87,10 @@ $loading_text    = __( 'Carregando…', 'obdc-simplex-news' );
                                         ?>
                                 </div>
 
+                                <div class="feed__sentinel" data-feed-sentinel aria-hidden="true"></div>
+
                                 <?php
+                                $auto_load_limit   = 2;
                                 $button_disabled   = $max_pages <= 1;
                                 $button_classes    = 'loadmore' . ( $button_disabled ? ' is-disabled' : '' );
                                 $button_attributes = $button_disabled ? ' disabled aria-disabled="true"' : ' aria-disabled="false"';
@@ -104,13 +107,36 @@ $loading_text    = __( 'Carregando…', 'obdc-simplex-news' );
                                         data-max-pages="<?php echo esc_attr( $max_pages ); ?>"
                                         data-button-text="<?php echo esc_attr( $load_more_text ); ?>"
                                         data-loading-text="<?php echo esc_attr( $loading_text ); ?>"
+                                        data-auto-load-limit="<?php echo esc_attr( $auto_load_limit ); ?>"
                                         <?php echo $button_attributes; ?>
                                 >
                                         <?php echo esc_html( $load_more_text ); ?>
                                 </button>
+
+                                <?php if ( $max_pages > 1 ) : ?>
+                                        <nav
+                                                class="feed__pagination feed__pagination--fallback"
+                                                aria-label="<?php echo esc_attr__( 'Paginação', 'obdc-simplex-news' ); ?>"
+                                                data-feed-pagination-fallback
+                                        >
+                                                <?php
+                                                echo wp_kses_post(
+                                                        paginate_links(
+                                                                array(
+                                                                        'total'     => $max_pages,
+                                                                        'current'   => 1,
+                                                                        'type'      => 'list',
+                                                                        'prev_text' => __( 'Anterior', 'obdc-simplex-news' ),
+                                                                        'next_text' => __( 'Próximo', 'obdc-simplex-news' ),
+                                                                )
+                                                        )
+                                                );
+                                                ?>
+                                        </nav>
+                                <?php endif; ?>
                         </div>
 
-			<!-- Sidebar - Mais lidas -->
+                        <!-- Sidebar - Mais lidas -->
 			<aside class="sidebar" aria-label="Mais lidas">
 				<?php get_template_part( 'template-parts/sidebar/most-read' ); ?>
 			</aside>

--- a/js/front-page.js
+++ b/js/front-page.js
@@ -22,10 +22,38 @@
                 }
 
                 const postsContainer = feedContainer.querySelector('[data-feed-items]');
+                let sentinel = feedContainer.querySelector('[data-feed-sentinel]');
+                const fallbackPagination = feedContainer.querySelector('[data-feed-pagination-fallback]');
                 const endpoint = loadMoreButton.dataset.endpoint;
                 const defaultText = loadMoreButton.dataset.buttonText || loadMoreButton.textContent;
                 const loadingText = loadMoreButton.dataset.loadingText || defaultText;
+                const autoLoadLimit = Math.max(0, parseInt(loadMoreButton.dataset.autoLoadLimit || '0', 10));
                 let isLoading = false;
+                let autoLoadCount = 0;
+                let observer = null;
+
+                if ( ! sentinel ) {
+                        sentinel = document.createElement('div');
+                        sentinel.setAttribute('data-feed-sentinel', '');
+                        sentinel.setAttribute('aria-hidden', 'true');
+
+                        if ( postsContainer ) {
+                                postsContainer.appendChild(sentinel);
+                        } else {
+                                feedContainer.appendChild(sentinel);
+                        }
+                }
+
+                if ( sentinel && ! sentinel.style.height ) {
+                        sentinel.style.height = '1px';
+                }
+
+                const hideFallbackPagination = () => {
+                        if ( fallbackPagination ) {
+                                fallbackPagination.setAttribute('hidden', '');
+                                fallbackPagination.setAttribute('aria-hidden', 'true');
+                        }
+                };
 
                 const disableButton = () => {
                         loadMoreButton.disabled = true;
@@ -43,6 +71,16 @@
                         loadMoreButton.textContent = defaultText;
                 };
 
+                const hideButton = () => {
+                        loadMoreButton.setAttribute('hidden', '');
+                        loadMoreButton.setAttribute('aria-hidden', 'true');
+                };
+
+                const showButton = () => {
+                        loadMoreButton.removeAttribute('hidden');
+                        loadMoreButton.setAttribute('aria-hidden', 'false');
+                };
+
                 const hasMorePages = () => {
                         const currentPage = parseInt(loadMoreButton.dataset.currentPage || '1', 10);
                         const maxPages = parseInt(loadMoreButton.dataset.maxPages || '1', 10);
@@ -50,22 +88,15 @@
                         return currentPage < maxPages;
                 };
 
-                const initialiseState = () => {
-                        if ( ! endpoint || ! hasMorePages() ) {
-                                disableButton();
-                                return false;
+                const stopObserver = () => {
+                        if ( observer ) {
+                                observer.disconnect();
+                                observer = null;
                         }
-
-                        enableButton();
-                        return true;
                 };
 
-                if ( ! initialiseState() ) {
-                        return;
-                }
-
-                loadMoreButton.addEventListener('click', () => {
-                        if ( isLoading || loadMoreButton.disabled ) {
+                const loadMore = ({ isAuto = false } = {}) => {
+                        if ( isLoading ) {
                                 return;
                         }
 
@@ -75,14 +106,27 @@
 
                         if ( nextPage > maxPages ) {
                                 disableButton();
+                                hideButton();
+                                stopObserver();
+                                return;
+                        }
+
+                        if ( isAuto && autoLoadLimit > 0 && autoLoadCount >= autoLoadLimit ) {
+                                stopObserver();
+                                enableButton();
+                                showButton();
                                 return;
                         }
 
                         isLoading = true;
+
+                        if ( ! isAuto ) {
+                                loadMoreButton.classList.add('is-loading');
+                                loadMoreButton.textContent = loadingText;
+                        }
+
                         loadMoreButton.disabled = true;
                         loadMoreButton.setAttribute('aria-disabled', 'true');
-                        loadMoreButton.classList.add('is-loading');
-                        loadMoreButton.textContent = loadingText;
 
                         let requestUrl;
 
@@ -119,7 +163,9 @@
                                                 loadMoreButton.dataset.maxPages = data.maxPages;
                                         }
 
-                                        if ( data && data.html ) {
+                                        const hasHtml = data && typeof data.html === 'string' && data.html.trim() !== '';
+
+                                        if ( hasHtml ) {
                                                 if ( postsContainer ) {
                                                         postsContainer.insertAdjacentHTML('beforeend', data.html);
                                                 } else {
@@ -129,22 +175,111 @@
 
                                         loadMoreButton.dataset.currentPage = String(nextPage);
 
-                                        if ( ! hasMorePages() || ! data || ! data.html ) {
-                                                disableButton();
-                                        } else {
-                                                enableButton();
+                                        const morePagesAvailable = hasMorePages();
+
+                                        if ( isAuto && autoLoadLimit > 0 && hasHtml ) {
+                                                autoLoadCount += 1;
                                         }
+
+                                        if ( ! hasHtml || ! morePagesAvailable ) {
+                                                disableButton();
+                                                hideButton();
+                                                stopObserver();
+                                                return;
+                                        }
+
+                                        enableButton();
+
+                                        if ( isAuto && autoLoadLimit > 0 && autoLoadCount < autoLoadLimit ) {
+                                                hideButton();
+                                                return;
+                                        }
+
+                                        if ( isAuto && autoLoadLimit > 0 && autoLoadCount >= autoLoadLimit ) {
+                                                stopObserver();
+                                        }
+
+                                        showButton();
                                 })
                                 .catch((error) => {
                                         // eslint-disable-next-line no-console
                                         console.error('Load more request failed:', error);
                                         enableButton();
+                                        showButton();
+                                        stopObserver();
                                 })
                                 .finally(() => {
                                         loadMoreButton.classList.remove('is-loading');
                                         loadMoreButton.textContent = defaultText;
                                         isLoading = false;
                                 });
+                };
+
+                const setupObserver = () => {
+                        if ( autoLoadLimit <= 0 ) {
+                                showButton();
+                                return;
+                        }
+
+                        if ( ! sentinel || ! ( 'IntersectionObserver' in window ) ) {
+                                showButton();
+                                return;
+                        }
+
+                        observer = new window.IntersectionObserver(
+                                (entries) => {
+                                        entries.forEach((entry) => {
+                                                if ( entry.isIntersecting ) {
+                                                        loadMore({ isAuto: true });
+                                                }
+                                        });
+                                },
+                                {
+                                        rootMargin: '0px 0px 400px 0px',
+                                }
+                        );
+
+                        observer.observe(sentinel);
+                };
+
+                const initialiseState = () => {
+                        hideFallbackPagination();
+
+                        if ( ! endpoint || ! hasMorePages() ) {
+                                disableButton();
+                                hideButton();
+                                stopObserver();
+                                return false;
+                        }
+
+                        enableButton();
+
+                        if ( autoLoadLimit > 0 ) {
+                                hideButton();
+                        } else {
+                                showButton();
+                        }
+
+                        setupObserver();
+
+                        if ( autoLoadLimit <= 0 || ! observer ) {
+                                showButton();
+                        }
+
+                        return true;
+                };
+
+                if ( ! initialiseState() ) {
+                        return;
+                }
+
+                loadMoreButton.addEventListener('click', () => {
+                        if ( isLoading || loadMoreButton.disabled ) {
+                                return;
+                        }
+
+                        showButton();
+                        loadMore({ isAuto: false });
                 });
         });
 })();


### PR DESCRIPTION
## Summary
- add sentinel markup, auto-load limit metadata, and pagination fallback to the front-page feed
- extend the front-page loader script to auto-fetch twice via IntersectionObserver before revealing the button and to hide the fallback pagination when JS runs

## Testing
- php -l front-page.php
- node -e "new Function(require('fs').readFileSync('js/front-page.js', 'utf8'));"

------
https://chatgpt.com/codex/tasks/task_e_68ce4adfb4b8833187d9708a2d4b1054