### PR TITLE
Implement infinite scroll auto-load with fallback

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -29,10 +29,12 @@ if ( ! empty( $featured_data['excluded_ids'] ) ) {
         $excluded_post_ids = obdc_simplex_news_get_front_page_excluded_post_ids();
 }
 
-$feed_endpoint   = rest_url( 'obdc-simplex-news/v1/front-page-feed' );
-$rest_nonce      = wp_create_nonce( 'wp_rest' );
-$load_more_text  = __( 'Carregar mais', 'obdc-simplex-news' );
-$loading_text    = __( 'Carregando…', 'obdc-simplex-news' );
+$feed_endpoint    = rest_url( 'obdc-simplex-news/v1/front-page-feed' );
+$rest_nonce       = wp_create_nonce( 'wp_rest' );
+$load_more_text   = __( 'Carregar mais', 'obdc-simplex-news' );
+$loading_text     = __( 'Carregando…', 'obdc-simplex-news' );
+$auto_load_limit  = apply_filters( 'obdc_simplex_news_front_page_autoload_limit', 2 );
+$auto_load_limit  = max( 0, absint( $auto_load_limit ) );
 
 ?>
 
@@ -94,6 +96,8 @@ $loading_text    = __( 'Carregando…', 'obdc-simplex-news' );
                                 ?>
 
                                 <!-- Load more button -->
+                                <div class="feed__sentinel" data-feed-sentinel aria-hidden="true"></div>
+
                                 <button
                                         class="<?php echo esc_attr( $button_classes ); ?>"
                                         type="button"
@@ -104,6 +108,7 @@ $loading_text    = __( 'Carregando…', 'obdc-simplex-news' );
                                         data-max-pages="<?php echo esc_attr( $max_pages ); ?>"
                                         data-button-text="<?php echo esc_attr( $load_more_text ); ?>"
                                         data-loading-text="<?php echo esc_attr( $loading_text ); ?>"
+                                        data-autoload-limit="<?php echo esc_attr( $auto_load_limit ); ?>"
                                         <?php echo $button_attributes; ?>
                                 >
                                         <?php echo esc_html( $load_more_text ); ?>

--- a/js/front-page.js
+++ b/js/front-page.js
@@ -22,86 +22,128 @@
                 }
 
                 const postsContainer = feedContainer.querySelector('[data-feed-items]');
+                const sentinel = feedContainer.querySelector('[data-feed-sentinel]');
                 const endpoint = loadMoreButton.dataset.endpoint;
                 const defaultText = loadMoreButton.dataset.buttonText || loadMoreButton.textContent;
                 const loadingText = loadMoreButton.dataset.loadingText || defaultText;
+                const autoLoadLimit = parseInt(loadMoreButton.dataset.autoloadLimit || '0', 10);
+                const supportsIntersectionObserver = typeof window !== 'undefined' && 'IntersectionObserver' in window;
+                const canUseAutoLoad = supportsIntersectionObserver && sentinel && autoLoadLimit > 0;
+
                 let isLoading = false;
+                let autoLoadCount = 0;
+                let observer;
 
-                const disableButton = () => {
-                        loadMoreButton.disabled = true;
-                        loadMoreButton.setAttribute('aria-disabled', 'true');
-                        loadMoreButton.classList.add('is-disabled');
-                        loadMoreButton.classList.remove('is-loading');
-                        loadMoreButton.textContent = defaultText;
+                const setButtonState = (state) => {
+                        switch ( state ) {
+                                case 'loading':
+                                        loadMoreButton.disabled = true;
+                                        loadMoreButton.setAttribute('aria-disabled', 'true');
+                                        loadMoreButton.classList.add('is-loading');
+                                        loadMoreButton.classList.remove('is-disabled');
+                                        loadMoreButton.textContent = loadingText;
+                                        break;
+                                case 'disabled':
+                                        loadMoreButton.disabled = true;
+                                        loadMoreButton.setAttribute('aria-disabled', 'true');
+                                        loadMoreButton.classList.add('is-disabled');
+                                        loadMoreButton.classList.remove('is-loading');
+                                        loadMoreButton.textContent = defaultText;
+                                        break;
+                                default:
+                                        loadMoreButton.disabled = false;
+                                        loadMoreButton.removeAttribute('disabled');
+                                        loadMoreButton.setAttribute('aria-disabled', 'false');
+                                        loadMoreButton.classList.remove('is-disabled');
+                                        loadMoreButton.classList.remove('is-loading');
+                                        loadMoreButton.textContent = defaultText;
+                                        break;
+                        }
                 };
 
-                const enableButton = () => {
-                        loadMoreButton.disabled = false;
-                        loadMoreButton.removeAttribute('disabled');
-                        loadMoreButton.setAttribute('aria-disabled', 'false');
-                        loadMoreButton.classList.remove('is-disabled');
-                        loadMoreButton.textContent = defaultText;
+                const getCurrentPage = () => parseInt(loadMoreButton.dataset.currentPage || '1', 10);
+                const getMaxPages = () => parseInt(loadMoreButton.dataset.maxPages || '1', 10);
+                const hasMorePages = () => getCurrentPage() < getMaxPages();
+
+                const hideButtonDuringAuto = () => {
+                        if ( ! canUseAutoLoad ) {
+                                return;
+                        }
+
+                        loadMoreButton.classList.add('is-hidden');
+                        loadMoreButton.setAttribute('aria-hidden', 'true');
+                        loadMoreButton.setAttribute('tabindex', '-1');
                 };
 
-                const hasMorePages = () => {
-                        const currentPage = parseInt(loadMoreButton.dataset.currentPage || '1', 10);
-                        const maxPages = parseInt(loadMoreButton.dataset.maxPages || '1', 10);
-
-                        return currentPage < maxPages;
+                const showButtonAfterAuto = () => {
+                        loadMoreButton.classList.remove('is-hidden');
+                        loadMoreButton.removeAttribute('aria-hidden');
+                        loadMoreButton.removeAttribute('tabindex');
                 };
 
                 const initialiseState = () => {
                         if ( ! endpoint || ! hasMorePages() ) {
-                                disableButton();
+                                setButtonState('disabled');
                                 return false;
                         }
 
-                        enableButton();
+                        setButtonState('default');
                         return true;
                 };
 
-                if ( ! initialiseState() ) {
-                        return;
-                }
-
-                loadMoreButton.addEventListener('click', () => {
-                        if ( isLoading || loadMoreButton.disabled ) {
-                                return;
-                        }
-
-                        const currentPage = parseInt(loadMoreButton.dataset.currentPage || '1', 10);
-                        const maxPages = parseInt(loadMoreButton.dataset.maxPages || '1', 10);
-                        const nextPage = currentPage + 1;
-
-                        if ( nextPage > maxPages ) {
-                                disableButton();
-                                return;
-                        }
-
-                        isLoading = true;
-                        loadMoreButton.disabled = true;
-                        loadMoreButton.setAttribute('aria-disabled', 'true');
-                        loadMoreButton.classList.add('is-loading');
-                        loadMoreButton.textContent = loadingText;
-
-                        let requestUrl;
-
+                const buildRequestUrl = (nextPage) => {
                         try {
                                 const url = new window.URL(endpoint);
                                 url.searchParams.set('page', String(nextPage));
-                                requestUrl = url.toString();
+                                return url.toString();
                         } catch ( error ) {
                                 const separator = endpoint.indexOf('?') === -1 ? '?' : '&';
-                                requestUrl = endpoint + separator + 'page=' + nextPage;
+                                return endpoint + separator + 'page=' + nextPage;
+                        }
+                };
+
+                const disconnectObserver = () => {
+                        if ( observer ) {
+                                observer.disconnect();
+                                observer = null;
+                        }
+                };
+
+                const observeSentinel = () => {
+                        if ( observer && sentinel ) {
+                                observer.observe(sentinel);
+                        }
+                };
+
+                const loadNextPage = ({ source = 'manual' } = {}) => {
+                        if ( isLoading || loadMoreButton.disabled ) {
+                                return Promise.resolve(false);
                         }
 
+                        const currentPage = getCurrentPage();
+                        const maxPages = getMaxPages();
+                        const nextPage = currentPage + 1;
+
+                        if ( nextPage > maxPages ) {
+                                setButtonState('disabled');
+                                return Promise.resolve(false);
+                        }
+
+                        isLoading = true;
+                        setButtonState('loading');
+
+                        if ( source === 'auto' ) {
+                                hideButtonDuringAuto();
+                        }
+
+                        const requestUrl = buildRequestUrl(nextPage);
                         const headers = { Accept: 'application/json' };
 
                         if ( loadMoreButton.dataset.nonce ) {
                                 headers['X-WP-Nonce'] = loadMoreButton.dataset.nonce;
                         }
 
-                        window
+                        return window
                                 .fetch(requestUrl, {
                                         method: 'GET',
                                         headers,
@@ -129,22 +171,88 @@
 
                                         loadMoreButton.dataset.currentPage = String(nextPage);
 
-                                        if ( ! hasMorePages() || ! data || ! data.html ) {
-                                                disableButton();
-                                        } else {
-                                                enableButton();
+                                        const morePagesAvailable = hasMorePages();
+                                        const hasNewContent = Boolean(data && data.html);
+
+                                        if ( source === 'auto' && hasNewContent ) {
+                                                autoLoadCount += 1;
                                         }
+
+                                        if ( ! morePagesAvailable || ! hasNewContent ) {
+                                                setButtonState('disabled');
+                                        } else if ( source === 'manual' ) {
+                                                setButtonState('default');
+                                        } else {
+                                                setButtonState('default');
+                                        }
+
+                                        return true;
                                 })
                                 .catch((error) => {
                                         // eslint-disable-next-line no-console
                                         console.error('Load more request failed:', error);
-                                        enableButton();
+
+                                        if ( source === 'manual' ) {
+                                                setButtonState('default');
+                                        } else {
+                                                showButtonAfterAuto();
+                                                setButtonState('default');
+                                        }
+
+                                        return false;
                                 })
                                 .finally(() => {
-                                        loadMoreButton.classList.remove('is-loading');
-                                        loadMoreButton.textContent = defaultText;
                                         isLoading = false;
                                 });
+                };
+
+                if ( ! initialiseState() ) {
+                        return;
+                }
+
+                loadMoreButton.addEventListener('click', () => {
+                        loadNextPage({ source: 'manual' });
                 });
+
+                if ( canUseAutoLoad && hasMorePages() ) {
+                        hideButtonDuringAuto();
+
+                        observer = new window.IntersectionObserver((entries) => {
+                                entries.forEach((entry) => {
+                                        if ( ! entry.isIntersecting ) {
+                                                return;
+                                        }
+
+                                        if ( isLoading || ! hasMorePages() || autoLoadCount >= autoLoadLimit ) {
+                                                return;
+                                        }
+
+                                        observer.unobserve(entry.target);
+
+                                        loadNextPage({ source: 'auto' }).then((success) => {
+                                                if ( ! success ) {
+                                                        disconnectObserver();
+                                                        showButtonAfterAuto();
+                                                        return;
+                                                }
+
+                                                if ( ! hasMorePages() || autoLoadCount >= autoLoadLimit ) {
+                                                        disconnectObserver();
+                                                        showButtonAfterAuto();
+
+                                                        if ( ! hasMorePages() ) {
+                                                                setButtonState('disabled');
+                                                        }
+                                                } else {
+                                                        observeSentinel();
+                                                }
+                                        });
+                                });
+                        }, { rootMargin: '200px 0px' });
+
+                        observeSentinel();
+                } else {
+                        showButtonAfterAuto();
+                }
         });
 })();

--- a/style.css
+++ b/style.css
@@ -384,9 +384,15 @@ main {
 	font-size: .7rem;
 }
 
+.loadmore.is-hidden {
+        visibility: hidden;
+        opacity: 0;
+        pointer-events: none;
+}
+
 .loadmore:hover {
-	background: #f9fafb;
-	border-color: #d1d5db;
+        background: #f9fafb;
+        border-color: #d1d5db;
 }
 
 /* Footer */


### PR DESCRIPTION
## Summary
- add a configurable autoload limit, sentinel markup, and dataset attributes to the front-page load more button
- refactor the front-page script to support IntersectionObserver-powered auto loading with a graceful fallback to the manual button
- add styling to hide the button only while automatic batches are running

## Testing
- php -l front-page.php

------
https://chatgpt.com/codex/tasks/task_e_68cf6810582c8331b05d2a73db288048