### PR TITLE
Ensure feed sentinel triggers mobile intersection observer

### DIFF
--- a/style.css
+++ b/style.css
@@ -384,6 +384,10 @@ main {
 	font-size: .7rem;
 }
 
+.feed__sentinel {
+        min-height: 1px;
+}
+
 .loadmore.is-hidden {
         visibility: hidden;
         opacity: 0;


### PR DESCRIPTION
## Summary
- add a minimum height to the feed sentinel so IntersectionObserver triggers reliably on mobile
- leave the load-more button fallback untouched for browsers without observer support

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cf852255e48331be0f71e1c906f392